### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mossland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds an MIT `LICENSE` file. This repo currently has **no license**.

**Why:** This repo accepts **external contributions** (many PRs). Without a license, the rights over contributed code are legally ambiguous — a license makes contribution and reuse terms clear.

**Why MIT:** it matches the org's existing convention — `alpha`, `alpha-mcp`, `agentic-orchestrator`, and `mossland/MossCoin-ERC20-2025` are all MIT.

> ⚠️ **Owner sign-off:** adding a license is a legal/ownership decision. This PR is a proposal — please have the repo/org owner confirm **MIT** (and the copyright holder line `Copyright (c) 2026 Mossland`) before merging. Adjust the holder/year if the org prefers a different form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)